### PR TITLE
Adding InfoOf generic support

### DIFF
--- a/AssemblyToProcess/GenericClass.cs
+++ b/AssemblyToProcess/GenericClass.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 
 public class GenericClass<T>
 {
-    string instanceField;
+    string instanceField = string.Empty;
 
     public FieldInfo GetInstanceField()
     {
@@ -15,7 +15,12 @@ public class GenericClass<T>
         return Info.OfField("AssemblyToProcess", "GenericClass`1<mscorlib|System.Int32>", "instanceField");
     }
 
-    static string staticField;
+    public FieldInfo GetInstanceFieldTyped()
+    {
+        return Info.OfField<GenericClass<int>>(nameof(instanceField));
+    }
+
+    static string staticField = string.Empty;
 
     public FieldInfo GetStaticField()
     {
@@ -25,6 +30,11 @@ public class GenericClass<T>
     public FieldInfo GetStaticFieldGeneric()
     {
         return Info.OfField("AssemblyToProcess", "GenericClass`1<mscorlib|System.Int32>", "staticField");
+    }
+
+    public FieldInfo GetStaticFieldTyped()
+    {
+        return Info.OfField<GenericClass<int>>(nameof(staticField));
     }
 
     string InstanceProperty { get; set; }
@@ -39,6 +49,11 @@ public class GenericClass<T>
         return Info.OfPropertyGet("AssemblyToProcess", "GenericClass`1<mscorlib|System.Int32>", "InstanceProperty");
     }
 
+    public MethodInfo GetInstanceGetPropertyTyped()
+    {
+        return Info.OfPropertyGet<GenericClass<int>>(nameof(InstanceProperty));
+    }
+
     public MethodInfo GetInstanceSetProperty()
     {
         return Info.OfPropertySet("AssemblyToProcess", "GenericClass`1", "InstanceProperty");
@@ -47,6 +62,11 @@ public class GenericClass<T>
     public MethodInfo GetInstanceSetPropertyGeneric()
     {
         return Info.OfPropertySet("AssemblyToProcess", "GenericClass`1<mscorlib|System.Int32>", "InstanceProperty");
+    }
+
+    public MethodInfo GetInstanceSetPropertyTyped()
+    {
+        return Info.OfPropertySet<GenericClass<int>>(nameof(InstanceProperty));
     }
 
     static string StaticProperty { get; set; }
@@ -61,6 +81,11 @@ public class GenericClass<T>
         return Info.OfPropertyGet("AssemblyToProcess", "GenericClass`1<mscorlib|System.Int32>", "StaticProperty");
     }
 
+    public MethodInfo GetStaticGetPropertyTyped()
+    {
+        return Info.OfPropertyGet<GenericClass<int>>(nameof(StaticProperty));
+    }
+
     public MethodInfo GetStaticSetProperty()
     {
         return Info.OfPropertySet("AssemblyToProcess", "GenericClass`1", "StaticProperty");
@@ -69,6 +94,11 @@ public class GenericClass<T>
     public MethodInfo GetStaticSetPropertyGeneric()
     {
         return Info.OfPropertySet("AssemblyToProcess", "GenericClass`1<mscorlib|System.Int32>", "StaticProperty");
+    }
+
+    public MethodInfo GetStaticSetPropertyTyped()
+    {
+        return Info.OfPropertySet<GenericClass<int>>(nameof(StaticProperty));
     }
 
     void InstanceMethod()
@@ -89,6 +119,11 @@ public class GenericClass<T>
         return Info.OfMethod("AssemblyToProcess", "GenericClass`1<mscorlib|System.Int32>", "InstanceMethod");
     }
 
+    public MethodInfo GetInstanceMethodTyped()
+    {
+        return Info.OfMethod<GenericClass<int>>(nameof(InstanceMethod));
+    }
+
     public MethodInfo GetStaticMethod()
     {
         return Info.OfMethod("AssemblyToProcess", "GenericClass`1", "StaticMethod");
@@ -97,6 +132,11 @@ public class GenericClass<T>
     public MethodInfo GetStaticMethodGeneric()
     {
         return Info.OfMethod("AssemblyToProcess", "GenericClass`1<mscorlib|System.Int32>", "StaticMethod");
+    }
+
+    public MethodInfo GetStaticMethodTyped()
+    {
+        return Info.OfMethod<GenericClass<int>>(nameof(StaticMethod));
     }
 
     public Type GetTypeInfo()
@@ -120,5 +160,10 @@ public class GenericClass<T>
     public ConstructorInfo GetConstructorInfoGeneric()
     {
         return Info.OfConstructor("AssemblyToProcess", "GenericClass`1<mscorlib|System.Int32>");
+    }
+
+    public ConstructorInfo GetConstructorInfoTyped()
+    {
+        return Info.OfConstructor<GenericClass<int>>();
     }
 }

--- a/AssemblyToProcess/InstanceClass.cs
+++ b/AssemblyToProcess/InstanceClass.cs
@@ -54,6 +54,10 @@ public class InstanceClass
         return Info.OfMethod("AssemblyToProcess", "InstanceClass", "MethodWithParams", "String, Int32");
     }
 
+    public MethodInfo GetMethodWithParamsTyped()
+    {
+        return Info.OfMethod<InstanceClass>(nameof(MethodWithParams), "String, Int32");
+    }
 
     void InstanceMethod() { }
     public MethodInfo GetInstanceMethod()
@@ -84,5 +88,10 @@ public class InstanceClass
     public ConstructorInfo GetConstructorInfoWithParam()
     {
         return Info.OfConstructor("AssemblyToProcess", "InstanceClass", "String");
+    }
+
+    public ConstructorInfo GetConstructorInfoWithParamTyped()
+    {
+        return Info.OfConstructor<InstanceClass>("String");
     }
 }

--- a/InfoOf.Fody/MethodProcessor.cs
+++ b/InfoOf.Fody/MethodProcessor.cs
@@ -31,16 +31,16 @@ public partial class ModuleWeaver
                     actions.Add(x => HandleOfMethod(copy, x, methodReference));
                     break;
                 case "OfField":
-                    actions.Add(x => HandleOfField(copy, x));
+                    actions.Add(x => HandleOfField(copy, x, methodReference));
                     break;
                 case "OfType":
                     actions.Add(x => HandleOfType(copy, x));
                     break;
                 case "OfPropertyGet":
-                    actions.Add(x => HandleOfPropertyGet(copy, x));
+                    actions.Add(x => HandleOfPropertyGet(copy, x, methodReference));
                     break;
                 case "OfPropertySet":
-                    actions.Add(x => HandleOfPropertySet(copy, x));
+                    actions.Add(x => HandleOfPropertySet(copy, x, methodReference));
                     break;
                 case "OfConstructor":
                     actions.Add(x => HandleOfConstructor(copy, x, methodReference));

--- a/InfoOf.Fody/TypeLoader.cs
+++ b/InfoOf.Fody/TypeLoader.cs
@@ -1,0 +1,24 @@
+﻿using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+partial class ModuleWeaver
+{
+    TypeReference LoadTypeReference(MethodReference methodReference, ILProcessor processor, Instruction instruction)
+    {
+        if (methodReference is GenericInstanceMethod genericReference)
+        {
+            return ModuleDefinition.ImportReference(genericReference.GenericArguments[0]);
+        }
+
+        var typeNameInstruction = instruction;
+        var typeName = GetLdString(typeNameInstruction);
+
+        var assemblyNameInstruction = typeNameInstruction.Previous;
+        var assemblyName = GetLdString(assemblyNameInstruction);
+
+        processor.Remove(typeNameInstruction);
+        processor.Remove(assemblyNameInstruction);
+
+        return GetTypeReference(assemblyName, typeName);
+    }
+}

--- a/InfoOf/Info.cs
+++ b/InfoOf/Info.cs
@@ -28,6 +28,22 @@ public static class Info
     }
 
     /// <summary>
+    /// Inject a MethodOf.
+    /// </summary>
+    public static MethodInfo OfMethod<T>(string methodName, string parameters)
+    {
+        throw BuildException();
+    }
+
+    /// <summary>
+    /// Inject a MethodOf.
+    /// </summary>
+    public static MethodInfo OfMethod<T>(string methodName)
+    {
+        throw BuildException();
+    }
+
+    /// <summary>
     /// Inject a ConstructorOf.
     /// </summary>
     public static ConstructorInfo OfConstructor(string assemblyName, string typeName, string parameters)
@@ -39,6 +55,22 @@ public static class Info
     /// Inject a ConstructorOf.
     /// </summary>
     public static ConstructorInfo OfConstructor(string assemblyName, string typeName)
+    {
+        throw BuildException();
+    }
+
+    /// <summary>
+    /// Inject a ConstructorOf.
+    /// </summary>
+    public static ConstructorInfo OfConstructor<T>(string parameters)
+    {
+        throw BuildException();
+    }
+
+    /// <summary>
+    /// Inject a ConstructorOf.
+    /// </summary>
+    public static ConstructorInfo OfConstructor<T>()
     {
         throw BuildException();
     }
@@ -60,6 +92,14 @@ public static class Info
     }
 
     /// <summary>
+    /// Inject a FieldOf.
+    /// </summary>
+    public static FieldInfo OfField<T>(string fieldName)
+    {
+        throw BuildException();
+    }
+
+    /// <summary>
     /// Inject a MethodOf for a property get.
     /// </summary>
     public static MethodInfo OfPropertyGet(string assemblyName, string typeName, string propertyName)
@@ -68,9 +108,25 @@ public static class Info
     }
 
     /// <summary>
+    /// Inject a MethodOf for a property get.
+    /// </summary>
+    public static MethodInfo OfPropertyGet<T>(string propertyName)
+    {
+        throw BuildException();
+    }
+
+    /// <summary>
     /// Inject a MethodOf for a property set.
     /// </summary>
     public static MethodInfo OfPropertySet(string assemblyName, string typeName, string propertyName)
+    {
+        throw BuildException();
+    }
+
+    /// <summary>
+    /// Inject a MethodOf for a property set.
+    /// </summary>
+    public static MethodInfo OfPropertySet<T>(string propertyName)
     {
         throw BuildException();
     }

--- a/Tests/IntegrationTests.cs
+++ b/Tests/IntegrationTests.cs
@@ -43,6 +43,16 @@ public class IntegrationTests :
     }
 
     [Fact]
+    public void GenericPropertyGetTyped()
+    {
+        var type = assembly.GetType("GenericClass`1");
+        type = type.MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetInstanceGetPropertyTyped();
+        Assert.NotNull(methodInfo);
+    }
+
+    [Fact]
     public void GenericPropertySet()
     {
         var type = assembly.GetType("GenericClass`1");
@@ -59,6 +69,16 @@ public class IntegrationTests :
         type = type.MakeGenericType(typeof(int));
         var instance = (dynamic) Activator.CreateInstance(type);
         MethodInfo methodInfo = instance.GetInstanceSetPropertyGeneric();
+        Assert.NotNull(methodInfo);
+    }
+
+    [Fact]
+    public void GenericPropertySetTyped()
+    {
+        var type = assembly.GetType("GenericClass`1");
+        type = type.MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetInstanceSetPropertyTyped();
         Assert.NotNull(methodInfo);
     }
 
@@ -83,6 +103,16 @@ public class IntegrationTests :
     }
 
     [Fact]
+    public void GenericStaticPropertyGetTyped()
+    {
+        var type = assembly.GetType("GenericClass`1");
+        type = type.MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetStaticGetPropertyTyped();
+        Assert.NotNull(methodInfo);
+    }
+
+    [Fact]
     public void GenericStaticPropertySet()
     {
         var type = assembly.GetType("GenericClass`1");
@@ -99,6 +129,16 @@ public class IntegrationTests :
         type = type.MakeGenericType(typeof(int));
         var instance = (dynamic) Activator.CreateInstance(type);
         MethodInfo methodInfo = instance.GetStaticSetPropertyGeneric();
+        Assert.NotNull(methodInfo);
+    }
+
+    [Fact]
+    public void GenericStaticPropertySetTyped()
+    {
+        var type = assembly.GetType("GenericClass`1");
+        type = type.MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetStaticSetPropertyTyped();
         Assert.NotNull(methodInfo);
     }
 
@@ -123,6 +163,16 @@ public class IntegrationTests :
     }
 
     [Fact]
+    public void GenericFieldTyped()
+    {
+        var type = assembly.GetType("GenericClass`1");
+        type = type.MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        FieldInfo fieldInfo = instance.GetInstanceFieldTyped();
+        Assert.NotNull(fieldInfo);
+    }
+
+    [Fact]
     public void GenericStaticField()
     {
         var type = assembly.GetType("GenericClass`1");
@@ -139,6 +189,16 @@ public class IntegrationTests :
         type = type.MakeGenericType(typeof(int));
         var instance = (dynamic) Activator.CreateInstance(type);
         FieldInfo fieldInfo = instance.GetStaticFieldGeneric();
+        Assert.NotNull(fieldInfo);
+    }
+
+    [Fact]
+    public void GenericStaticFieldTyped()
+    {
+        var type = assembly.GetType("GenericClass`1");
+        type = type.MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        FieldInfo fieldInfo = instance.GetStaticFieldTyped();
         Assert.NotNull(fieldInfo);
     }
 
@@ -172,6 +232,16 @@ public class IntegrationTests :
     }
 
     [Fact]
+    public void GenericMethodTyped()
+    {
+        var type = assembly.GetType("GenericClass`1");
+        type = type.MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetInstanceMethodTyped();
+        Assert.NotNull(methodInfo);
+    }
+
+    [Fact]
     public void GenericStaticMethod()
     {
         var type = assembly.GetType("GenericClass`1");
@@ -188,6 +258,16 @@ public class IntegrationTests :
         type = type.MakeGenericType(typeof(int));
         var instance = (dynamic) Activator.CreateInstance(type);
         MethodInfo methodInfo = instance.GetStaticMethodGeneric();
+        Assert.NotNull(methodInfo);
+    }
+
+    [Fact]
+    public void GenericStaticMethodTyped()
+    {
+        var type = assembly.GetType("GenericClass`1");
+        type = type.MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetStaticMethodTyped();
         Assert.NotNull(methodInfo);
     }
 
@@ -316,6 +396,15 @@ public class IntegrationTests :
     }
 
     [Fact]
+    public void InstanceMethodWithParamsTyped()
+    {
+        var type = assembly.GetType("InstanceClass");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetMethodWithParamsTyped();
+        Assert.NotNull(methodInfo);
+    }
+
+    [Fact]
     public void StaticMethod()
     {
         var type = assembly.GetType("InstanceClass");
@@ -370,6 +459,15 @@ public class IntegrationTests :
     }
 
     [Fact]
+    public void InstanceConstructorWithParamTyped()
+    {
+        var type = assembly.GetType("InstanceClass");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo constructorInfo = instance.GetConstructorInfoWithParamTyped();
+        Assert.NotNull(constructorInfo);
+    }
+
+    [Fact]
     public void GenericConstructor()
     {
         var type = assembly.GetType("GenericClass`1");
@@ -389,7 +487,17 @@ public class IntegrationTests :
         Assert.NotNull(constructorInfo);
     }
 
-    public IntegrationTests(ITestOutputHelper output) : 
+    [Fact]
+    public void GenericConstructorTyped()
+    {
+        var type = assembly.GetType("GenericClass`1");
+        type = type.MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo constructorInfo = instance.GetConstructorInfoTyped();
+        Assert.NotNull(constructorInfo);
+    }
+
+    public IntegrationTests(ITestOutputHelper output) :
         base(output)
     {
     }

--- a/readme.md
+++ b/readme.md
@@ -40,11 +40,21 @@ Add `<InfoOf/>` to [FodyWeavers.xml](https://github.com/Fody/Home/blob/master/pa
 
 ```csharp
 var type = Info.OfType("AssemblyName", "MyClass");
+
 var method = Info.OfMethod("AssemblyName", "MyClass", "MyMethod");
+var methodTyped = Info.OfMethod<MyClass>("MyMethod");
+
 var constructor = Info.OfConstructor("AssemblyName", "MyClass");
+var constructorTyped = Info.OfConstructor<MyClass>();
+
 var getProperty = Info.OfPropertyGet("AssemblyName", "MyClass", "MyProperty");
+var getPropertyTyped = Info.OfPropertyGet<MyClass>("MyProperty");
+
 var setProperty = Info.OfPropertySet("AssemblyName", "MyClass", "MyProperty");
+var setPropertyTyped = Info.OfPropertySet<MyClass>("MyProperty");
+
 var field = Info.OfField("AssemblyName", "MyClass", "myField");
+var fieldTyped = Info.OfField<MyClass>("myField");
 ```
 
 
@@ -52,11 +62,21 @@ var field = Info.OfField("AssemblyName", "MyClass", "myField");
 
 ```c#
 var type = typeof(MyClass);
+
 var method = methodof(MyClass.MyMethod);
+var methodTyped = methodof(MyClass.MyMethod);
+
 var constructor = methodof(MyClass..ctor);
+var constructorTyped = methodof(MyClass..ctor);
+
 var getProperty = methodof(MyClass.get_MyProperty);
+var getPropertyTyped = methodof(MyClass.get_MyProperty);
+
 var setProperty = methodof(MyClass.set_MyProperty);
+var setPropertyTyped = methodof(MyClass.set_MyProperty);
+
 var field = fieldof(MyClass.myField);
+var fieldTyped = fieldof(MyClass.myField);
 ```
 
 


### PR DESCRIPTION
Adding support for allowing getting type information using generics instead of using the assembly name/type name strings.

I didn't add support for the Info.OfType overload since it seemed silly since it is essentially the typeof operator.