### PR TITLE
fixing issue with updating block jumps

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -63,6 +63,9 @@ csharp_new_line_before_members_in_anonymous_types = true:error
 #braces
 #csharp_prefer_braces = true:error
 
+# Space preferences
+csharp_space_after_cast = true:error
+
 # msbuild
 [*.{csproj,targets,props}]
 indent_size = 2

--- a/AssemblyToProcess/AssemblyToProcess.csproj
+++ b/AssemblyToProcess/AssemblyToProcess.csproj
@@ -9,4 +9,20 @@
     <ProjectReference Include="..\AssemblyToReference\AssemblyToReference.csproj" />
     <ProjectReference Include="..\InfoOf\InfoOf.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="WithBlocks.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>WithBlocks.Generated.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="WithBlocks.Generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>WithBlocks.tt</DependentUpon>
+    </Compile>
+  </ItemGroup>
 </Project>

--- a/AssemblyToProcess/WithBlocks.Generated.cs
+++ b/AssemblyToProcess/WithBlocks.Generated.cs
@@ -1,0 +1,1231 @@
+﻿using System.Reflection;
+
+public class WithBlocks
+{
+    public WithBlocks() {}
+    public WithBlocks(int _) {}
+
+    int instanceField = 0;
+
+    int InstanceMethod() => 0;
+    int InstanceMethodWithParam(int i) => i;
+
+    int InstanceProperty { get; set; }
+
+    public ConstructorInfo GetOfConstructor_ForBlock()
+    {
+        ConstructorInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfConstructor("AssemblyToProcess", "WithBlocks");
+        }
+
+        return info;
+    }
+
+    public ConstructorInfo GetOfConstructor_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfConstructor("AssemblyToProcess", "WithBlocks");
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public ConstructorInfo GetOfConstructor_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfConstructor("AssemblyToProcess", "WithBlocks");
+    }
+
+    public ConstructorInfo GetOfConstructorTyped_ForBlock()
+    {
+        ConstructorInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfConstructor<WithBlocks>();
+        }
+
+        return info;
+    }
+
+    public ConstructorInfo GetOfConstructorTyped_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfConstructor<WithBlocks>();
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public ConstructorInfo GetOfConstructorTyped_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfConstructor<WithBlocks>();
+    }
+
+    public ConstructorInfo GetOfConstructorWithParam_ForBlock()
+    {
+        ConstructorInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfConstructor("AssemblyToProcess", "WithBlocks", "Int32");
+        }
+
+        return info;
+    }
+
+    public ConstructorInfo GetOfConstructorWithParam_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfConstructor("AssemblyToProcess", "WithBlocks", "Int32");
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public ConstructorInfo GetOfConstructorWithParam_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfConstructor("AssemblyToProcess", "WithBlocks", "Int32");
+    }
+
+    public ConstructorInfo GetOfConstructorTypedWithParam_ForBlock()
+    {
+        ConstructorInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfConstructor<WithBlocks>("Int32");
+        }
+
+        return info;
+    }
+
+    public ConstructorInfo GetOfConstructorTypedWithParam_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfConstructor<WithBlocks>("Int32");
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public ConstructorInfo GetOfConstructorTypedWithParam_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfConstructor<WithBlocks>("Int32");
+    }
+
+    public FieldInfo GetOfField_ForBlock()
+    {
+        FieldInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfField("AssemblyToProcess", "WithBlocks", nameof(instanceField));
+        }
+
+        return info;
+    }
+
+    public FieldInfo GetOfField_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfField("AssemblyToProcess", "WithBlocks", nameof(instanceField));
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public FieldInfo GetOfField_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfField("AssemblyToProcess", "WithBlocks", nameof(instanceField));
+    }
+
+    public FieldInfo GetOfFieldTyped_ForBlock()
+    {
+        FieldInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfField<WithBlocks>(nameof(instanceField));
+        }
+
+        return info;
+    }
+
+    public FieldInfo GetOfFieldTyped_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfField<WithBlocks>(nameof(instanceField));
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public FieldInfo GetOfFieldTyped_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfField<WithBlocks>(nameof(instanceField));
+    }
+
+    public MethodInfo GetOfMethod_ForBlock()
+    {
+        MethodInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfMethod("AssemblyToProcess", "WithBlocks", nameof(InstanceMethod));
+        }
+
+        return info;
+    }
+
+    public MethodInfo GetOfMethod_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfMethod("AssemblyToProcess", "WithBlocks", nameof(InstanceMethod));
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public MethodInfo GetOfMethod_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfMethod("AssemblyToProcess", "WithBlocks", nameof(InstanceMethod));
+    }
+
+    public MethodInfo GetOfMethodTyped_ForBlock()
+    {
+        MethodInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfMethod<WithBlocks>(nameof(InstanceMethod));
+        }
+
+        return info;
+    }
+
+    public MethodInfo GetOfMethodTyped_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfMethod<WithBlocks>(nameof(InstanceMethod));
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public MethodInfo GetOfMethodTyped_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfMethod<WithBlocks>(nameof(InstanceMethod));
+    }
+
+    public MethodInfo GetOfMethodWithParam_ForBlock()
+    {
+        MethodInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfMethod("AssemblyToProcess", "WithBlocks", nameof(InstanceMethodWithParam), "Int32");
+        }
+
+        return info;
+    }
+
+    public MethodInfo GetOfMethodWithParam_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfMethod("AssemblyToProcess", "WithBlocks", nameof(InstanceMethodWithParam), "Int32");
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public MethodInfo GetOfMethodWithParam_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfMethod("AssemblyToProcess", "WithBlocks", nameof(InstanceMethodWithParam), "Int32");
+    }
+
+    public MethodInfo GetOfMethodTypedWithParam_ForBlock()
+    {
+        MethodInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfMethod<WithBlocks>(nameof(InstanceMethodWithParam), "Int32");
+        }
+
+        return info;
+    }
+
+    public MethodInfo GetOfMethodTypedWithParam_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfMethod<WithBlocks>(nameof(InstanceMethodWithParam), "Int32");
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public MethodInfo GetOfMethodTypedWithParam_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfMethod<WithBlocks>(nameof(InstanceMethodWithParam), "Int32");
+    }
+
+    public MethodInfo GetOfPropertyGet_ForBlock()
+    {
+        MethodInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfPropertyGet("AssemblyToProcess", "WithBlocks", nameof(InstanceProperty));
+        }
+
+        return info;
+    }
+
+    public MethodInfo GetOfPropertyGet_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfPropertyGet("AssemblyToProcess", "WithBlocks", nameof(InstanceProperty));
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public MethodInfo GetOfPropertyGet_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfPropertyGet("AssemblyToProcess", "WithBlocks", nameof(InstanceProperty));
+    }
+
+    public MethodInfo GetOfPropertyGetTyped_ForBlock()
+    {
+        MethodInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfPropertyGet<WithBlocks>(nameof(InstanceProperty));
+        }
+
+        return info;
+    }
+
+    public MethodInfo GetOfPropertyGetTyped_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfPropertyGet<WithBlocks>(nameof(InstanceProperty));
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public MethodInfo GetOfPropertyGetTyped_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfPropertyGet<WithBlocks>(nameof(InstanceProperty));
+    }
+
+    public MethodInfo GetOfPropertySet_ForBlock()
+    {
+        MethodInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfPropertySet("AssemblyToProcess", "WithBlocks", nameof(InstanceProperty));
+        }
+
+        return info;
+    }
+
+    public MethodInfo GetOfPropertySet_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfPropertySet("AssemblyToProcess", "WithBlocks", nameof(InstanceProperty));
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public MethodInfo GetOfPropertySet_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfPropertySet("AssemblyToProcess", "WithBlocks", nameof(InstanceProperty));
+    }
+
+    public MethodInfo GetOfPropertySetTyped_ForBlock()
+    {
+        MethodInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfPropertySet<WithBlocks>(nameof(InstanceProperty));
+        }
+
+        return info;
+    }
+
+    public MethodInfo GetOfPropertySetTyped_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfPropertySet<WithBlocks>(nameof(InstanceProperty));
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public MethodInfo GetOfPropertySetTyped_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfPropertySet<WithBlocks>(nameof(InstanceProperty));
+    }
+}
+
+public class WithBlocksGeneric<T>
+{
+    public WithBlocksGeneric() {}
+    public WithBlocksGeneric(int _) {}
+
+    int instanceField = 0;
+
+    int InstanceMethod() => 0;
+    int InstanceMethodWithParam(int i) => i;
+
+    int InstanceProperty { get; set; }
+
+    public ConstructorInfo GetOfConstructor_ForBlock()
+    {
+        ConstructorInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfConstructor("AssemblyToProcess", "WithBlocksGeneric`1");
+        }
+
+        return info;
+    }
+
+    public ConstructorInfo GetOfConstructor_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfConstructor("AssemblyToProcess", "WithBlocksGeneric`1");
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public ConstructorInfo GetOfConstructor_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfConstructor("AssemblyToProcess", "WithBlocksGeneric`1");
+    }
+
+    public ConstructorInfo GetOfConstructorTyped_ForBlock()
+    {
+        ConstructorInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfConstructor<WithBlocksGeneric<int>>();
+        }
+
+        return info;
+    }
+
+    public ConstructorInfo GetOfConstructorTyped_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfConstructor<WithBlocksGeneric<int>>();
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public ConstructorInfo GetOfConstructorTyped_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfConstructor<WithBlocksGeneric<int>>();
+    }
+
+    public ConstructorInfo GetOfConstructorWithParam_ForBlock()
+    {
+        ConstructorInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfConstructor("AssemblyToProcess", "WithBlocksGeneric`1", "Int32");
+        }
+
+        return info;
+    }
+
+    public ConstructorInfo GetOfConstructorWithParam_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfConstructor("AssemblyToProcess", "WithBlocksGeneric`1", "Int32");
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public ConstructorInfo GetOfConstructorWithParam_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfConstructor("AssemblyToProcess", "WithBlocksGeneric`1", "Int32");
+    }
+
+    public ConstructorInfo GetOfConstructorTypedWithParam_ForBlock()
+    {
+        ConstructorInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfConstructor<WithBlocksGeneric<int>>("Int32");
+        }
+
+        return info;
+    }
+
+    public ConstructorInfo GetOfConstructorTypedWithParam_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfConstructor<WithBlocksGeneric<int>>("Int32");
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public ConstructorInfo GetOfConstructorTypedWithParam_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfConstructor<WithBlocksGeneric<int>>("Int32");
+    }
+
+    public FieldInfo GetOfField_ForBlock()
+    {
+        FieldInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfField("AssemblyToProcess", "WithBlocksGeneric`1", nameof(instanceField));
+        }
+
+        return info;
+    }
+
+    public FieldInfo GetOfField_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfField("AssemblyToProcess", "WithBlocksGeneric`1", nameof(instanceField));
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public FieldInfo GetOfField_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfField("AssemblyToProcess", "WithBlocksGeneric`1", nameof(instanceField));
+    }
+
+    public FieldInfo GetOfFieldTyped_ForBlock()
+    {
+        FieldInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfField<WithBlocksGeneric<int>>(nameof(instanceField));
+        }
+
+        return info;
+    }
+
+    public FieldInfo GetOfFieldTyped_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfField<WithBlocksGeneric<int>>(nameof(instanceField));
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public FieldInfo GetOfFieldTyped_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfField<WithBlocksGeneric<int>>(nameof(instanceField));
+    }
+
+    public MethodInfo GetOfMethod_ForBlock()
+    {
+        MethodInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfMethod("AssemblyToProcess", "WithBlocksGeneric`1", nameof(InstanceMethod));
+        }
+
+        return info;
+    }
+
+    public MethodInfo GetOfMethod_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfMethod("AssemblyToProcess", "WithBlocksGeneric`1", nameof(InstanceMethod));
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public MethodInfo GetOfMethod_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfMethod("AssemblyToProcess", "WithBlocksGeneric`1", nameof(InstanceMethod));
+    }
+
+    public MethodInfo GetOfMethodTyped_ForBlock()
+    {
+        MethodInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfMethod<WithBlocksGeneric<int>>(nameof(InstanceMethod));
+        }
+
+        return info;
+    }
+
+    public MethodInfo GetOfMethodTyped_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfMethod<WithBlocksGeneric<int>>(nameof(InstanceMethod));
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public MethodInfo GetOfMethodTyped_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfMethod<WithBlocksGeneric<int>>(nameof(InstanceMethod));
+    }
+
+    public MethodInfo GetOfMethodWithParam_ForBlock()
+    {
+        MethodInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfMethod("AssemblyToProcess", "WithBlocksGeneric`1", nameof(InstanceMethodWithParam), "Int32");
+        }
+
+        return info;
+    }
+
+    public MethodInfo GetOfMethodWithParam_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfMethod("AssemblyToProcess", "WithBlocksGeneric`1", nameof(InstanceMethodWithParam), "Int32");
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public MethodInfo GetOfMethodWithParam_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfMethod("AssemblyToProcess", "WithBlocksGeneric`1", nameof(InstanceMethodWithParam), "Int32");
+    }
+
+    public MethodInfo GetOfMethodTypedWithParam_ForBlock()
+    {
+        MethodInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfMethod<WithBlocksGeneric<int>>(nameof(InstanceMethodWithParam), "Int32");
+        }
+
+        return info;
+    }
+
+    public MethodInfo GetOfMethodTypedWithParam_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfMethod<WithBlocksGeneric<int>>(nameof(InstanceMethodWithParam), "Int32");
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public MethodInfo GetOfMethodTypedWithParam_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfMethod<WithBlocksGeneric<int>>(nameof(InstanceMethodWithParam), "Int32");
+    }
+
+    public MethodInfo GetOfPropertyGet_ForBlock()
+    {
+        MethodInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfPropertyGet("AssemblyToProcess", "WithBlocksGeneric`1", nameof(InstanceProperty));
+        }
+
+        return info;
+    }
+
+    public MethodInfo GetOfPropertyGet_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfPropertyGet("AssemblyToProcess", "WithBlocksGeneric`1", nameof(InstanceProperty));
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public MethodInfo GetOfPropertyGet_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfPropertyGet("AssemblyToProcess", "WithBlocksGeneric`1", nameof(InstanceProperty));
+    }
+
+    public MethodInfo GetOfPropertyGetTyped_ForBlock()
+    {
+        MethodInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfPropertyGet<WithBlocksGeneric<int>>(nameof(InstanceProperty));
+        }
+
+        return info;
+    }
+
+    public MethodInfo GetOfPropertyGetTyped_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfPropertyGet<WithBlocksGeneric<int>>(nameof(InstanceProperty));
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public MethodInfo GetOfPropertyGetTyped_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfPropertyGet<WithBlocksGeneric<int>>(nameof(InstanceProperty));
+    }
+
+    public MethodInfo GetOfPropertySet_ForBlock()
+    {
+        MethodInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfPropertySet("AssemblyToProcess", "WithBlocksGeneric`1", nameof(InstanceProperty));
+        }
+
+        return info;
+    }
+
+    public MethodInfo GetOfPropertySet_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfPropertySet("AssemblyToProcess", "WithBlocksGeneric`1", nameof(InstanceProperty));
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public MethodInfo GetOfPropertySet_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfPropertySet("AssemblyToProcess", "WithBlocksGeneric`1", nameof(InstanceProperty));
+    }
+
+    public MethodInfo GetOfPropertySetTyped_ForBlock()
+    {
+        MethodInfo info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {
+            info = Info.OfPropertySet<WithBlocksGeneric<int>>(nameof(InstanceProperty));
+        }
+
+        return info;
+    }
+
+    public MethodInfo GetOfPropertySetTyped_SwitchBlock()
+    {
+        int i;
+        switch (InstanceMethod())
+        {
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }
+
+        var info = Info.OfPropertySet<WithBlocksGeneric<int>>(nameof(InstanceProperty));
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }
+
+    public MethodInfo GetOfPropertySetTyped_TryBlock()
+    {
+        try
+        {
+            InstanceMethod();
+        }
+        catch
+        {
+            throw;
+        }
+
+        return Info.OfPropertySet<WithBlocksGeneric<int>>(nameof(InstanceProperty));
+    }
+}

--- a/AssemblyToProcess/WithBlocks.tt
+++ b/AssemblyToProcess/WithBlocks.tt
@@ -1,0 +1,92 @@
+﻿<#@ template debug="true" language="C#" #>
+<#@ output extension="Generated.cs" #>
+<#@ assembly name="System.Core" #>
+using System.Reflection;
+<#= GenerateClass("WithBlocks", "WithBlocks", "WithBlocks") #>
+<#= GenerateClass("WithBlocksGeneric<T>", "WithBlocksGeneric", "WithBlocksGeneric`1") #>
+<#+
+string GenerateClass(string classDefinition, string className, string classRef) => $@"
+public class {classDefinition}
+{{
+    public {className}() {{}}
+    public {className}(int _) {{}}
+
+    int instanceField = 0;
+
+    int InstanceMethod() => 0;
+    int InstanceMethodWithParam(int i) => i;
+
+    int InstanceProperty {{ get; set; }}
+
+    {GenerateBlocks("ConstructorInfo", "OfConstructor", classRef, "", false)}
+
+    {GenerateBlocks("ConstructorInfo", "OfConstructor", classRef, "", true)}
+
+    {GenerateBlocks("FieldInfo", "OfField", classRef, ", nameof(instanceField)", false)}
+
+    {GenerateBlocks("MethodInfo", "OfMethod", classRef, ", nameof(InstanceMethod)", false)}
+
+    {GenerateBlocks("MethodInfo", "OfMethod", classRef, ", nameof(InstanceMethodWithParam)", true)}
+
+    {GenerateBlocks("MethodInfo", "OfPropertyGet", classRef, ", nameof(InstanceProperty)", false)}
+
+    {GenerateBlocks("MethodInfo", "OfPropertySet", classRef, ", nameof(InstanceProperty)", false)}
+}}";
+
+string GenerateBlocks(string infoType, string infoOf, string className, string infoParams, bool withParam)
+{
+    var ofModifier = withParam ? ", \"Int32\"" : "";
+    var nameModifier = withParam ? "WithParam" : "";
+
+    var nonGenericCall = $"Info.{infoOf}(\"AssemblyToProcess\", \"{className}\"{infoParams}{ofModifier});";
+    var genericCall = $"Info.{infoOf}<{className.Replace("`1", "<int>")}>({infoParams}{ofModifier});";
+
+    return $@"{GenerateBlocksCore(infoType, infoOf + nameModifier, nonGenericCall)}
+
+    {GenerateBlocksCore(infoType, infoOf + "Typed" + nameModifier, genericCall)}".Replace("(, ", "(");
+}
+
+string GenerateBlocksCore(string infoType, string methodName, string infoCall) =>
+    $@"public {infoType} Get{methodName}_ForBlock()
+    {{
+        {infoType} info = null;
+
+        for (var i = 0; i < 1; ++i)
+        {{
+            info = {infoCall}
+        }}
+
+        return info;
+    }}
+
+    public {infoType} Get{methodName}_SwitchBlock()
+    {{
+        int i;
+        switch (InstanceMethod())
+        {{
+            case 0: i = 0; break;
+            case 1: i = 1; break;
+            default: i = -1; break;
+        }}
+
+        var info = {infoCall}
+
+        InstanceMethodWithParam(i);
+
+        return info;
+    }}
+
+    public {infoType} Get{methodName}_TryBlock()
+    {{
+        try
+        {{
+            InstanceMethod();
+        }}
+        catch
+        {{
+            throw;
+        }}
+
+        return {infoCall}
+    }}";
+#>

--- a/InfoOf.Fody/MethodBodyExtensions.cs
+++ b/InfoOf.Fody/MethodBodyExtensions.cs
@@ -1,0 +1,21 @@
+using System.Linq;
+using Mono.Cecil.Cil;
+
+public static class MethodBodyExtensions
+{
+    public static void UpdateInstructions(this MethodBody body,
+        Instruction oldInstruction, Instruction newInstruction)
+    {
+        foreach (var updateInstruction in body.Instructions
+            .Where(i => i.Operand == oldInstruction))
+        {
+            updateInstruction.Operand = newInstruction;
+        }
+
+        foreach (var updateInstruction in body.ExceptionHandlers
+            .Where(h => h.HandlerEnd == oldInstruction))
+        {
+            updateInstruction.HandlerEnd = newInstruction;
+        }
+    }
+}

--- a/InfoOf.Fody/OfFieldHandler.cs
+++ b/InfoOf.Fody/OfFieldHandler.cs
@@ -11,7 +11,7 @@ public partial class ModuleWeaver
         var fieldNameInstruction = instruction.Previous;
         var fieldName = GetLdString(fieldNameInstruction);
 
-        var typeReference = LoadTypeReference(ofFieldReference, ilProcessor, fieldNameInstruction.Previous);
+        var (typeReference, toReplace) = LoadTypeReference(ofFieldReference, ilProcessor, fieldNameInstruction.Previous);
         var typeDefinition = typeReference.Resolve();
 
         var fieldDefinition = typeDefinition.Fields.FirstOrDefault(x => x.Name == fieldName);
@@ -39,6 +39,8 @@ public partial class ModuleWeaver
         fieldNameInstruction.OpCode = OpCodes.Ldtoken;
         fieldNameInstruction.Operand = fieldReference;
 
+        ilProcessor.Body.UpdateInstructions(toReplace, fieldNameInstruction);
+
         if (typeDefinition.HasGenericParameters)
         {
             ilProcessor.InsertBefore(instruction, Instruction.Create(OpCodes.Ldtoken, typeReference));
@@ -49,5 +51,4 @@ public partial class ModuleWeaver
             instruction.Operand = getFieldFromHandle;
         }
     }
-
 }

--- a/InfoOf.Fody/OfMethodHandler.cs
+++ b/InfoOf.Fody/OfMethodHandler.cs
@@ -31,7 +31,7 @@ public partial class ModuleWeaver
 
         var methodName = GetLdString(methodNameInstruction);
 
-        var typeReference = LoadTypeReference(ofMethodReference, ilProcessor, methodNameInstruction.Previous);
+        var (typeReference, toReplace) = LoadTypeReference(ofMethodReference, ilProcessor, methodNameInstruction.Previous);
         var typeDefinition = typeReference.Resolve();
 
         var methodDefinitions = typeDefinition.FindMethodDefinitions(methodName, parameters);
@@ -54,6 +54,8 @@ public partial class ModuleWeaver
 
         methodNameInstruction.OpCode = OpCodes.Ldtoken;
         methodNameInstruction.Operand = methodReference;
+
+        ilProcessor.Body.UpdateInstructions(toReplace, methodNameInstruction);
 
         if (typeDefinition.HasGenericParameters)
         {

--- a/InfoOf.Fody/OfPropertyHandler.cs
+++ b/InfoOf.Fody/OfPropertyHandler.cs
@@ -21,7 +21,7 @@ public partial class ModuleWeaver
         var propertyNameInstruction = instruction.Previous;
         var propertyName = GetLdString(propertyNameInstruction);
 
-        var typeReference = LoadTypeReference(propertyReference, ilProcessor, propertyNameInstruction.Previous);
+        var (typeReference, toReplace) = LoadTypeReference(propertyReference, ilProcessor, propertyNameInstruction.Previous);
         var typeDefinition = typeReference.Resolve();
 
         var property = typeDefinition.Properties.FirstOrDefault(x => x.Name == propertyName);
@@ -40,6 +40,8 @@ public partial class ModuleWeaver
 
         propertyNameInstruction.OpCode = OpCodes.Ldtoken;
         propertyNameInstruction.Operand = methodReference;
+
+        ilProcessor.Body.UpdateInstructions(toReplace, propertyNameInstruction);
 
         if (typeDefinition.HasGenericParameters)
         {

--- a/InfoOf.Fody/TypeLoader.cs
+++ b/InfoOf.Fody/TypeLoader.cs
@@ -3,11 +3,11 @@ using Mono.Cecil.Cil;
 
 partial class ModuleWeaver
 {
-    TypeReference LoadTypeReference(MethodReference methodReference, ILProcessor processor, Instruction instruction)
+    (TypeReference, Instruction) LoadTypeReference(MethodReference methodReference, ILProcessor processor, Instruction instruction)
     {
         if (methodReference is GenericInstanceMethod genericReference)
         {
-            return ModuleDefinition.ImportReference(genericReference.GenericArguments[0]);
+            return (ModuleDefinition.ImportReference(genericReference.GenericArguments[0]), instruction);
         }
 
         var typeNameInstruction = instruction;
@@ -19,6 +19,6 @@ partial class ModuleWeaver
         processor.Remove(typeNameInstruction);
         processor.Remove(assemblyNameInstruction);
 
-        return GetTypeReference(assemblyName, typeName);
+        return (GetTypeReference(assemblyName, typeName), assemblyNameInstruction);
     }
 }

--- a/Tests/IntegrationTests.cs
+++ b/Tests/IntegrationTests.cs
@@ -5,7 +5,7 @@ using Fody;
 using Xunit;
 using Xunit.Abstractions;
 
-public class IntegrationTests :
+public partial class IntegrationTests :
     XunitLoggingBase
 {
     static Assembly assembly;

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -16,4 +16,20 @@
     <ProjectReference Include="..\InfoOf\InfoOf.csproj" />
     <ProjectReference Include="..\InfoOf.Fody\InfoOf.Fody.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="WithBlocksTests.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>WithBlocksTests.Generated.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="WithBlocksTests.Generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>WithBlocksTests.tt</DependentUpon>
+    </Compile>
+  </ItemGroup>
 </Project>

--- a/Tests/WithBlocksTests.Generated.cs
+++ b/Tests/WithBlocksTests.Generated.cs
@@ -1,0 +1,762 @@
+﻿using System;
+using System.Reflection;
+using Xunit;
+
+partial class IntegrationTests
+{
+    [Fact]
+    public void WithBlocks_GetOfConstructor_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo info = instance.GetOfConstructor_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfConstructor_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo info = instance.GetOfConstructor_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfConstructor_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo info = instance.GetOfConstructor_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfConstructorTyped_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo info = instance.GetOfConstructorTyped_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfConstructorTyped_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo info = instance.GetOfConstructorTyped_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfConstructorTyped_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo info = instance.GetOfConstructorTyped_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfConstructor_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo info = instance.GetOfConstructor_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfConstructor_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo info = instance.GetOfConstructor_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfConstructor_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo info = instance.GetOfConstructor_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfConstructorTyped_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo info = instance.GetOfConstructorTyped_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfConstructorTyped_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo info = instance.GetOfConstructorTyped_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfConstructorTyped_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo info = instance.GetOfConstructorTyped_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfConstructorWithParam_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo info = instance.GetOfConstructorWithParam_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfConstructorWithParam_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo info = instance.GetOfConstructorWithParam_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfConstructorWithParam_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo info = instance.GetOfConstructorWithParam_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfConstructorTypedWithParam_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo info = instance.GetOfConstructorTypedWithParam_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfConstructorTypedWithParam_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo info = instance.GetOfConstructorTypedWithParam_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfConstructorTypedWithParam_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo info = instance.GetOfConstructorTypedWithParam_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfConstructorWithParam_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo info = instance.GetOfConstructorWithParam_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfConstructorWithParam_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo info = instance.GetOfConstructorWithParam_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfConstructorWithParam_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo info = instance.GetOfConstructorWithParam_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfConstructorTypedWithParam_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo info = instance.GetOfConstructorTypedWithParam_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfConstructorTypedWithParam_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo info = instance.GetOfConstructorTypedWithParam_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfConstructorTypedWithParam_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        ConstructorInfo info = instance.GetOfConstructorTypedWithParam_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfField_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        FieldInfo info = instance.GetOfField_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfField_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        FieldInfo info = instance.GetOfField_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfField_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        FieldInfo info = instance.GetOfField_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfFieldTyped_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        FieldInfo info = instance.GetOfFieldTyped_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfFieldTyped_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        FieldInfo info = instance.GetOfFieldTyped_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfFieldTyped_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        FieldInfo info = instance.GetOfFieldTyped_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfField_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        FieldInfo info = instance.GetOfField_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfField_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        FieldInfo info = instance.GetOfField_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfField_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        FieldInfo info = instance.GetOfField_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfFieldTyped_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        FieldInfo info = instance.GetOfFieldTyped_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfFieldTyped_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        FieldInfo info = instance.GetOfFieldTyped_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfFieldTyped_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        FieldInfo info = instance.GetOfFieldTyped_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfMethod_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfMethod_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfMethod_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfMethod_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfMethod_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfMethod_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfMethodTyped_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfMethodTyped_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfMethodTyped_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfMethodTyped_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfMethodTyped_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfMethodTyped_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfMethod_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfMethod_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfMethod_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfMethod_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfMethod_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfMethod_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfMethodTyped_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfMethodTyped_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfMethodTyped_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfMethodTyped_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfMethodTyped_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfMethodTyped_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfMethodWithParam_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfMethodWithParam_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfMethodWithParam_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfMethodWithParam_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfMethodWithParam_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfMethodWithParam_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfMethodTypedWithParam_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfMethodTypedWithParam_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfMethodTypedWithParam_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfMethodTypedWithParam_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfMethodTypedWithParam_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfMethodTypedWithParam_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfMethodWithParam_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfMethodWithParam_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfMethodWithParam_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfMethodWithParam_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfMethodWithParam_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfMethodWithParam_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfMethodTypedWithParam_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfMethodTypedWithParam_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfMethodTypedWithParam_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfMethodTypedWithParam_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfMethodTypedWithParam_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfMethodTypedWithParam_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfPropertyGet_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfPropertyGet_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfPropertyGet_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfPropertyGet_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfPropertyGet_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfPropertyGet_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfPropertyGetTyped_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfPropertyGetTyped_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfPropertyGetTyped_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfPropertyGetTyped_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfPropertyGetTyped_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfPropertyGetTyped_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfPropertyGet_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfPropertyGet_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfPropertyGet_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfPropertyGet_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfPropertyGet_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfPropertyGet_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfPropertyGetTyped_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfPropertyGetTyped_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfPropertyGetTyped_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfPropertyGetTyped_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfPropertyGetTyped_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfPropertyGetTyped_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfPropertySet_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfPropertySet_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfPropertySet_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfPropertySet_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfPropertySet_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfPropertySet_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfPropertySetTyped_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfPropertySetTyped_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfPropertySetTyped_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfPropertySetTyped_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocks_GetOfPropertySetTyped_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocks");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfPropertySetTyped_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfPropertySet_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfPropertySet_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfPropertySet_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfPropertySet_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfPropertySet_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfPropertySet_TryBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfPropertySetTyped_ForBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfPropertySetTyped_ForBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfPropertySetTyped_SwitchBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfPropertySetTyped_SwitchBlock();
+        Assert.NotNull(info);
+    }
+
+    [Fact]
+    public void WithBlocksGeneric_GetOfPropertySetTyped_TryBlock()
+    {
+        var type = assembly.GetType("WithBlocksGeneric`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo info = instance.GetOfPropertySetTyped_TryBlock();
+        Assert.NotNull(info);
+    }
+}

--- a/Tests/WithBlocksTests.tt
+++ b/Tests/WithBlocksTests.tt
@@ -1,0 +1,67 @@
+﻿<#@ template debug="true" language="C#" #>
+<#@ output extension="Generated.cs" #>
+<#@ assembly name="System.Core" #>
+using System;
+using System.Reflection;
+using Xunit;
+
+partial class IntegrationTests
+{
+    <#= GenerateTests("ConstructorInfo", "OfConstructor") #>
+
+    <#= GenerateTests("ConstructorInfo", "OfConstructor", "WithParam") #>
+
+    <#= GenerateTests("FieldInfo", "OfField") #>
+
+    <#= GenerateTests("MethodInfo", "OfMethod") #>
+
+    <#= GenerateTests("MethodInfo", "OfMethod", "WithParam") #>
+
+    <#= GenerateTests("MethodInfo", "OfPropertyGet") #>
+
+    <#= GenerateTests("MethodInfo", "OfPropertySet") #>
+}
+<#+
+string GenerateTests(string infoType, string infoOf, string withModifier = "") =>
+    $@"{GenerateTestsCore(infoType, infoOf, withModifier, false)}
+
+    {GenerateTestsCore(infoType, infoOf, "Typed" + withModifier, false)}
+
+    {GenerateTestsCore(infoType, infoOf, withModifier, true)}
+
+    {GenerateTestsCore(infoType, infoOf, "Typed" + withModifier, true)}";
+
+string GenerateTestsCore(string infoType, string infoOf, string withModifier, bool generic)
+{
+    var classModifier = generic ? "Generic" : "";
+    var classRefModifier = generic ? "Generic`1" : "";
+    var typeModifier = generic ? ".MakeGenericType(typeof(int))" : "";
+
+    return $@"[Fact]
+    public void WithBlocks{classModifier}_Get{infoOf}{withModifier}_ForBlock()
+    {{
+        var type = assembly.GetType(""WithBlocks{classRefModifier}""){typeModifier};
+        var instance = (dynamic) Activator.CreateInstance(type);
+        {infoType} info = instance.Get{infoOf}{withModifier}_ForBlock();
+        Assert.NotNull(info);
+    }}
+
+    [Fact]
+    public void WithBlocks{classModifier}_Get{infoOf}{withModifier}_SwitchBlock()
+    {{
+        var type = assembly.GetType(""WithBlocks{classRefModifier}""){typeModifier};
+        var instance = (dynamic) Activator.CreateInstance(type);
+        {infoType} info = instance.Get{infoOf}{withModifier}_SwitchBlock();
+        Assert.NotNull(info);
+    }}
+
+    [Fact]
+    public void WithBlocks{classModifier}_Get{infoOf}{withModifier}_TryBlock()
+    {{
+        var type = assembly.GetType(""WithBlocks{classRefModifier}""){typeModifier};
+        var instance = (dynamic) Activator.CreateInstance(type);
+        {infoType} info = instance.Get{infoOf}{withModifier}_TryBlock();
+        Assert.NotNull(info);
+    }}";
+}
+#>


### PR DESCRIPTION
I was looking at the FodyAddinSamples repository the other day and noticed that Fody/FodyAddinSamples#124 was failing due to issues running the automated build.

Since my last commit is what broke this, I went ahead and looked into it.

This PR fixes the issue.