### PR TITLE
adding support for indexers

### DIFF
--- a/AssemblyToProcess/GenericClass.cs
+++ b/AssemblyToProcess/GenericClass.cs
@@ -166,4 +166,56 @@ public class GenericClass<T>
     {
         return Info.OfConstructor<GenericClass<int>>();
     }
+
+    public object this[string index]
+    {
+        get => null;
+        set => throw new NotImplementedException();
+    }
+
+    public double this[int index]
+    {
+        get => default;
+        set => throw new NotImplementedException();
+    }
+
+    public MethodInfo GetStringIndexerGet()
+    {
+        return Info.OfIndexerGet("AssemblyToProcess", "GenericClass`1<mscorlib|System.Int32>", "String");
+    }
+
+    public MethodInfo GetIntIndexerGet()
+    {
+        return Info.OfIndexerGet("AssemblyToProcess", "GenericClass`1<mscorlib|System.Int32>", "Int32");
+    }
+
+    public MethodInfo GetStringIndexerSet()
+    {
+        return Info.OfIndexerSet("AssemblyToProcess", "GenericClass`1<mscorlib|System.Int32>", "String");
+    }
+
+    public MethodInfo GetIntIndexerSet()
+    {
+        return Info.OfIndexerSet("AssemblyToProcess", "GenericClass`1<mscorlib|System.Int32>", "Int32");
+    }
+
+    public MethodInfo GetStringIndexerGetTyped()
+    {
+        return Info.OfIndexerGet<GenericClass<int>>("String");
+    }
+
+    public MethodInfo GetIntIndexerGetTyped()
+    {
+        return Info.OfIndexerGet<GenericClass<int>>("Int32");
+    }
+
+    public MethodInfo GetStringIndexerSetTyped()
+    {
+        return Info.OfIndexerSet<GenericClass<int>>("String");
+    }
+
+    public MethodInfo GetIntIndexerSetTyped()
+    {
+        return Info.OfIndexerSet<GenericClass<int>>("Int32");
+    }
 }

--- a/AssemblyToProcess/InstanceClass.cs
+++ b/AssemblyToProcess/InstanceClass.cs
@@ -122,4 +122,56 @@ public class InstanceClass
     {
         return Info.OfConstructor<InstanceClass>("String");
     }
+
+    public object this[string index]
+    {
+        get => null;
+        set => throw new NotImplementedException();
+    }
+
+    public double this[int index]
+    {
+        get => default;
+        set => throw new NotImplementedException();
+    }
+
+    public MethodInfo GetStringIndexerGet()
+    {
+        return Info.OfIndexerGet("AssemblyToProcess", "InstanceClass", "String");
+    }
+
+    public MethodInfo GetIntIndexerGet()
+    {
+        return Info.OfIndexerGet("AssemblyToProcess", "InstanceClass", "Int32");
+    }
+
+    public MethodInfo GetStringIndexerSet()
+    {
+        return Info.OfIndexerSet("AssemblyToProcess", "InstanceClass", "String");
+    }
+
+    public MethodInfo GetIntIndexerSet()
+    {
+        return Info.OfIndexerSet("AssemblyToProcess", "InstanceClass", "Int32");
+    }
+
+    public MethodInfo GetStringIndexerGetTyped()
+    {
+        return Info.OfIndexerGet<InstanceClass>("String");
+    }
+
+    public MethodInfo GetIntIndexerGetTyped()
+    {
+        return Info.OfIndexerGet<InstanceClass>("Int32");
+    }
+
+    public MethodInfo GetStringIndexerSetTyped()
+    {
+        return Info.OfIndexerSet<InstanceClass>("String");
+    }
+
+    public MethodInfo GetIntIndexerSetTyped()
+    {
+        return Info.OfIndexerSet<InstanceClass>("Int32");
+    }
 }

--- a/InfoOf.Fody/MethodProcessor.cs
+++ b/InfoOf.Fody/MethodProcessor.cs
@@ -45,6 +45,12 @@ public partial class ModuleWeaver
                 case "OfConstructor":
                     actions.Add(x => HandleOfConstructor(copy, x, methodReference));
                     break;
+                case "OfIndexerGet":
+                    actions.Add(x => HandleOfIndexerGet(copy, x, methodReference));
+                    break;
+                case "OfIndexerSet":
+                    actions.Add(x => HandleOfIndexerSet(copy, x, methodReference));
+                    break;
             }
         }
 

--- a/InfoOf.Fody/OfIndexerHandler.cs
+++ b/InfoOf.Fody/OfIndexerHandler.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Fody;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+public partial class ModuleWeaver
+{
+    void HandleOfIndexerGet(Instruction instruction, ILProcessor ilProcessor, MethodReference ofIndexerGetReference)
+    {
+        HandleOfIndexer(instruction, ilProcessor, ofIndexerGetReference, x => x.GetMethod, (_, p) => p);
+    }
+
+    void HandleOfIndexerSet(Instruction instruction, ILProcessor ilProcessor, MethodReference ofIndexerSetReference)
+    {
+        HandleOfIndexer(instruction, ilProcessor, ofIndexerSetReference, x => x.SetMethod, (d, p) => p.Append(d.PropertyType.Name).ToList());
+    }
+
+    void HandleOfIndexer(Instruction instruction, ILProcessor ilProcessor, MethodReference propertyReference,
+        Func<PropertyDefinition, MethodDefinition> func, Func<PropertyDefinition, List<string>, List<string>> getParameters)
+    {
+        var parametersInstruction = instruction.Previous;
+        var parameters = GetLdString(parametersInstruction)
+            .Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(x => x.Trim())
+            .ToList();
+
+        const string propertyName = "Item";
+
+        var typeReferenceData = LoadTypeReference(propertyReference, ilProcessor, parametersInstruction.Previous);
+        var typeDefinition = typeReferenceData.TypeReference.Resolve();
+
+        var property = typeDefinition.Properties.FirstOrDefault(x => x.Name == propertyName &&
+            (func(x)?.HasSameParams(getParameters(x, parameters)) ?? false));
+
+        if (property == null)
+        {
+            throw new WeavingException("Could not find indexer.");
+        }
+        var methodDefinition = func(property);
+        if (methodDefinition == null)
+        {
+            throw new WeavingException("Could not find indexer.");
+        }
+
+        var methodReference = ModuleDefinition.ImportReference(methodDefinition);
+
+        parametersInstruction.OpCode = OpCodes.Ldtoken;
+        parametersInstruction.Operand = methodReference;
+
+        ilProcessor.Body.UpdateInstructions(typeReferenceData.Instruction, parametersInstruction);
+
+        if (typeDefinition.HasGenericParameters)
+        {
+            ilProcessor.InsertBefore(instruction, Instruction.Create(OpCodes.Ldtoken, typeReferenceData.TypeReference));
+            instruction.Operand = getMethodFromHandleGeneric;
+        }
+        else
+        {
+            instruction.Operand = getMethodFromHandle;
+        }
+
+        ilProcessor.InsertAfter(instruction, Instruction.Create(OpCodes.Castclass, methodInfoType));
+    }
+}

--- a/InfoOf/Info.cs
+++ b/InfoOf/Info.cs
@@ -130,4 +130,36 @@ public static class Info
     {
         throw BuildException();
     }
+
+    /// <summary>
+    /// Inject a MethodOf for an indexer get.
+    /// </summary>
+    public static MethodInfo OfIndexerGet(string assemblyName, string typeName, string parameters)
+    {
+        throw BuildException();
+    }
+
+    /// <summary>
+    /// Inject a MethodOf for an indexer get.
+    /// </summary>
+    public static MethodInfo OfIndexerGet<T>(string parameters)
+    {
+        throw BuildException();
+    }
+
+    /// <summary>
+    /// Inject a MethodOf for an indexer set.
+    /// </summary>
+    public static MethodInfo OfIndexerSet(string assemblyName, string typeName, string parameters)
+    {
+        throw BuildException();
+    }
+
+    /// <summary>
+    /// Inject a MethodOf for an indexer set.
+    /// </summary>
+    public static MethodInfo OfIndexerSet<T>(string parameters)
+    {
+        throw BuildException();
+    }
 }

--- a/Tests/IntegrationTests.cs
+++ b/Tests/IntegrationTests.cs
@@ -484,6 +484,150 @@ public partial class IntegrationTests
     }
 
     [Fact]
+    public void GetStringIndexerGet()
+    {
+        var type = assembly.GetType("InstanceClass");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetStringIndexerGet();
+        Assert.NotNull(methodInfo);
+    }
+
+    [Fact]
+    public void GetIntIndexerGet()
+    {
+        var type = assembly.GetType("InstanceClass");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetIntIndexerGet();
+        Assert.NotNull(methodInfo);
+    }
+
+    [Fact]
+    public void GetStringIndexerSet()
+    {
+        var type = assembly.GetType("InstanceClass");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetStringIndexerSet();
+        Assert.NotNull(methodInfo);
+    }
+
+    [Fact]
+    public void GetIntIndexerSet()
+    {
+        var type = assembly.GetType("InstanceClass");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetIntIndexerSet();
+        Assert.NotNull(methodInfo);
+    }
+
+    [Fact]
+    public void GetStringIndexerGetTyped()
+    {
+        var type = assembly.GetType("InstanceClass");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetStringIndexerGetTyped();
+        Assert.NotNull(methodInfo);
+    }
+
+    [Fact]
+    public void GetIntIndexerGetTyped()
+    {
+        var type = assembly.GetType("InstanceClass");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetIntIndexerGetTyped();
+        Assert.NotNull(methodInfo);
+    }
+
+    [Fact]
+    public void GetStringIndexerSetTyped()
+    {
+        var type = assembly.GetType("InstanceClass");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetStringIndexerSetTyped();
+        Assert.NotNull(methodInfo);
+    }
+
+    [Fact]
+    public void GetIntIndexerSetTyped()
+    {
+        var type = assembly.GetType("InstanceClass");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetIntIndexerSetTyped();
+        Assert.NotNull(methodInfo);
+    }
+
+    [Fact]
+    public void GetStringIndexerGet_Generic()
+    {
+        var type = assembly.GetType("GenericClass`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetStringIndexerGet();
+        Assert.NotNull(methodInfo);
+    }
+
+    [Fact]
+    public void GetIntIndexerGet_Generic()
+    {
+        var type = assembly.GetType("GenericClass`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetIntIndexerGet();
+        Assert.NotNull(methodInfo);
+    }
+
+    [Fact]
+    public void GetStringIndexerSet_Generic()
+    {
+        var type = assembly.GetType("GenericClass`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetStringIndexerSet();
+        Assert.NotNull(methodInfo);
+    }
+
+    [Fact]
+    public void GetIntIndexerSet_Generic()
+    {
+        var type = assembly.GetType("GenericClass`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetIntIndexerSet();
+        Assert.NotNull(methodInfo);
+    }
+
+    [Fact]
+    public void GetStringIndexerGetTyped_Generic()
+    {
+        var type = assembly.GetType("GenericClass`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetStringIndexerGetTyped();
+        Assert.NotNull(methodInfo);
+    }
+
+    [Fact]
+    public void GetIntIndexerGetTyped_Generic()
+    {
+        var type = assembly.GetType("GenericClass`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetIntIndexerGetTyped();
+        Assert.NotNull(methodInfo);
+    }
+
+    [Fact]
+    public void GetStringIndexerSetTyped_Generic()
+    {
+        var type = assembly.GetType("GenericClass`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetStringIndexerSetTyped();
+        Assert.NotNull(methodInfo);
+    }
+
+    [Fact]
+    public void GetIntIndexerSetTyped_Generic()
+    {
+        var type = assembly.GetType("GenericClass`1").MakeGenericType(typeof(int));
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetIntIndexerSetTyped();
+        Assert.NotNull(methodInfo);
+    }
+
+    [Fact]
     public void GenericConstructor()
     {
         var type = assembly.GetType("GenericClass`1");

--- a/Tests/Snippets.cs
+++ b/Tests/Snippets.cs
@@ -21,6 +21,12 @@
         var field = Info.OfField("AssemblyName", "MyClass", "myField");
         var fieldTyped = Info.OfField<MyClass>("myField");
 
+        var getIndexer = Info.OfIndexerGet("AssemblyName", "MyClass", "Int32");
+        var getIndexerTyped = Info.OfIndexerGet<MyClass>("Int32");
+
+        var setIndexer = Info.OfIndexerSet("AssemblyName", "MyClass", "Int32");
+        var setIndexerTyped = Info.OfIndexerSet<MyClass>("Int32");
+
         #endregion
 
 /*
@@ -42,6 +48,12 @@ var setPropertyTyped = methodof(MyClass.set_MyProperty);
 
 var field = fieldof(MyClass.myField);
 var fieldTyped = fieldof(MyClass.myField);
+
+var getIndexer = methodof(MyClass.get_Item);
+var getIndexerTyped = methodof(MyClass.get_Item);
+
+var setIndexer = methodof(MyClass.set_Item);
+var setIndexerTyped = methodof(MyClass.set_Item);
 
 #endregion
 */

--- a/readme.md
+++ b/readme.md
@@ -67,8 +67,14 @@ var setPropertyTyped = Info.OfPropertySet<MyClass>("MyProperty");
 
 var field = Info.OfField("AssemblyName", "MyClass", "myField");
 var fieldTyped = Info.OfField<MyClass>("myField");
+
+var getIndexer = Info.OfIndexerGet("AssemblyName", "MyClass", "Int32");
+var getIndexerTyped = Info.OfIndexerGet<MyClass>("Int32");
+
+var setIndexer = Info.OfIndexerSet("AssemblyName", "MyClass", "Int32");
+var setIndexerTyped = Info.OfIndexerSet<MyClass>("Int32");
 ```
-<sup><a href='/Tests/Snippets.cs#L5-L24' title='Snippet source file'>snippet source</a> | <a href='#snippet-usage' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/Tests/Snippets.cs#L5-L30' title='Snippet source file'>snippet source</a> | <a href='#snippet-usage' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -93,8 +99,14 @@ var setPropertyTyped = methodof(MyClass.set_MyProperty);
 
 var field = fieldof(MyClass.myField);
 var fieldTyped = fieldof(MyClass.myField);
+
+var getIndexer = methodof(MyClass.get_Item);
+var getIndexerTyped = methodof(MyClass.get_Item);
+
+var setIndexer = methodof(MyClass.set_Item);
+var setIndexerTyped = methodof(MyClass.set_Item);
 ```
-<sup><a href='/Tests/Snippets.cs#L27-L46' title='Snippet source file'>snippet source</a> | <a href='#snippet-usagecompiled' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/Tests/Snippets.cs#L33-L58' title='Snippet source file'>snippet source</a> | <a href='#snippet-usagecompiled' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 


### PR DESCRIPTION
#### You should already be a Patron

I am a Patron.

#### Description

Adds support for getting the method info of indexer property get/set methods.

When you have a class with an indexer property like

``` csharp
class MyClass
{
    private object[] collection;

    public object this[int index]
    {
        get => collection[index];
        set => collection[index] = value;
    }
}
```

You will now be able to call

``` csharp
var getInfo = Info.OfIndexerGet<MyClass>("Int32");
var setInfo = Info.OfIndexerSet<MyClass>("Int32");
```

#### The solution

Copied the OfPropertyHandler file & updated references\parameters to support indexers.

Set method could have been coded to require return type in parameter list like

``` csharp
var setInfo = Info.OfIndexerSet<MyClass>("Int32,Object");
```

But since I already had the property info, I updated to automatically add the parameter type so get & set parameters wouldn't differ.

#### Todos

 * [ ] <s>Related issues</s>
 * [x] Tests
 * [x] Documentation