### PR TITLE
Method with multiple generic params bug fix

### DIFF
--- a/AssemblyToProcess/InstanceClass.cs
+++ b/AssemblyToProcess/InstanceClass.cs
@@ -57,6 +57,15 @@ public class InstanceClass
     static void MethodWithParams(string param1, int param2)
     {
     }
+
+    static void MethodWithSimpleGenericParams(string param1, List<int> param2)
+    {
+    }
+
+    static void MethodWithComplexGenericParams(string param1, Dictionary<int, string> param2)
+    {
+    }
+
     // ReSharper restore UnusedParameter.Local
 
     public MethodInfo GetMethodWithParams()
@@ -72,6 +81,16 @@ public class InstanceClass
     public MethodInfo GetMethodWithParamsTyped()
     {
         return Info.OfMethod<InstanceClass>(nameof(MethodWithParams), "String, Int32");
+    }
+
+    public MethodInfo GetMethodWithSimpleGenericParamsTyped()
+    {
+        return Info.OfMethod<InstanceClass>(nameof(MethodWithSimpleGenericParams), "String, System.Collections.Generic.List`1<System.Int32>");
+    }
+
+    public MethodInfo GetMethodWithComplexGenericParamsTyped()
+    {
+        return Info.OfMethod<InstanceClass>(nameof(MethodWithComplexGenericParams), "String, System.Collections.Generic.Dictionary`2<System.Int32, System.String>");
     }
 
     void InstanceMethod()

--- a/InfoOf.Fody/OfConstructor.cs
+++ b/InfoOf.Fody/OfConstructor.cs
@@ -18,10 +18,7 @@ public partial class ModuleWeaver
             case 1:
             case 3:
                 parametersInstruction = instruction.Previous;
-                parameters = GetLdString(parametersInstruction)
-                    .Split([","], StringSplitOptions.RemoveEmptyEntries)
-                    .Select(_ => _.Trim())
-                    .ToList();
+                parameters = GetLdString(parametersInstruction).GetParameters();
                 typeNameInstruction = parametersInstruction.Previous;
                 break;
             default:

--- a/InfoOf.Fody/OfIndexerHandler.cs
+++ b/InfoOf.Fody/OfIndexerHandler.cs
@@ -16,10 +16,7 @@ public partial class ModuleWeaver
         Func<PropertyDefinition, MethodDefinition> func, Func<PropertyDefinition, List<string>, List<string>> getParameters)
     {
         var parametersInstruction = instruction.Previous;
-        var parameters = GetLdString(parametersInstruction)
-            .Split([","], StringSplitOptions.RemoveEmptyEntries)
-            .Select(_ => _.Trim())
-            .ToList();
+        var parameters = GetLdString(parametersInstruction).GetParameters();
 
         const string propertyName = "Item";
 

--- a/InfoOf.Fody/OfMethodHandler.cs
+++ b/InfoOf.Fody/OfMethodHandler.cs
@@ -10,10 +10,7 @@ public partial class ModuleWeaver
         if (ofMethodReference.Parameters.Count is 2 or 4)
         {
             parametersInstruction = instruction.Previous;
-            parameters = GetLdString(parametersInstruction)
-                .Split([","], StringSplitOptions.RemoveEmptyEntries)
-                .Select(_ => _.Trim())
-                .ToList();
+            parameters = GetLdString(parametersInstruction).GetParameters();
             methodNameInstruction = parametersInstruction.Previous;
         }
         else

--- a/InfoOf.Fody/ParamChecker.cs
+++ b/InfoOf.Fody/ParamChecker.cs
@@ -55,4 +55,24 @@ public static class ParamChecker
         }
         return true;
     }
+
+    public static List<string> GetParameters(this string parameters) =>
+        parameters
+            .Aggregate(
+                (0, "", Array.Empty<string>()),
+                (acc, c) => (acc.Item1, c) switch
+                {
+                    (0, ',') => (0, "", [.. acc.Item3, acc.Item2]),
+                    (_, '<') => (acc.Item1 + 1, $"{acc.Item2}{c}", acc.Item3),
+                    (_, '>') => (acc.Item1 - 1, $"{acc.Item2}{c}", acc.Item3),
+                    (_, ' ') => acc,
+                    (_, _) => (acc.Item1, $"{acc.Item2}{c}", acc.Item3)
+                },
+                acc => acc.Item2 switch
+                {
+                    "" => acc.Item3,
+                    _ => [.. acc.Item3, acc.Item2]
+                })
+            .Select(_ => _.Trim())
+            .ToList();
 }

--- a/Tests/IntegrationTests.cs
+++ b/Tests/IntegrationTests.cs
@@ -409,6 +409,24 @@ public partial class IntegrationTests
     }
 
     [Fact]
+    public void InstanceMethodWithSimpleGenericParamsTyped()
+    {
+        var type = assembly.GetType("InstanceClass");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetMethodWithSimpleGenericParamsTyped();
+        Assert.NotNull(methodInfo);
+    }
+    
+    [Fact]
+    public void InstanceMethodWithComplexGenericParamsTyped()
+    {
+        var type = assembly.GetType("InstanceClass");
+        var instance = (dynamic) Activator.CreateInstance(type);
+        MethodInfo methodInfo = instance.GetMethodWithComplexGenericParamsTyped();
+        Assert.NotNull(methodInfo);
+    }
+
+    [Fact]
     public void StaticMethod()
     {
         var type = assembly.GetType("InstanceClass");

--- a/readme.md
+++ b/readme.md
@@ -118,7 +118,6 @@ var setIndexerTyped = methodof(MyClass.set_Item);
 - Parameters are specified as comma separated list, e.g. `"System.String, System.Int32"`.
 - For every parameter, the first namespace part can be omitted, so `"String, Int32"` works, too.
 - Nested namespaces are not handled, only `"Regex"` won't work, but `"System.Text.RegularExpressions.Regex"` or `"Text.RegularExpressions.Regex"`.
-- Generic types with more than one type param are not supported in method parameters. ```"System.Collections.Generic.List`1<System.Int32>"``` works, but ```"System.Collections.Generic.Dictionary`2<System.Int32, System.String>"``` does not. (see #583)
 
 ## Finding Generic Methods
 

--- a/readme.source.md
+++ b/readme.source.md
@@ -57,7 +57,6 @@ snippet: UsageCompiled
 - Parameters are specified as comma separated list, e.g. `"System.String, System.Int32"`.
 - For every parameter, the first namespace part can be omitted, so `"String, Int32"` works, too.
 - Nested namespaces are not handled, only `"Regex"` won't work, but `"System.Text.RegularExpressions.Regex"` or `"Text.RegularExpressions.Regex"`.
-- Generic types with more than one type param are not supported in method parameters. ```"System.Collections.Generic.List`1<System.Int32>"``` works, but ```"System.Collections.Generic.Dictionary`2<System.Int32, System.String>"``` does not. (see #583)
 
 ## Finding Generic Methods
 


### PR DESCRIPTION
#### You should already be a Patron

I am a Patron.

#### Description

fixes #583

#### The solution

The issue was that the code was splitting on all `,` chars. I've updated to only split on `,` chars which are not within a `<...>` structure.

#### Todos

 * [x] Related issues
 * [x] Tests
 * [x] Documentation